### PR TITLE
refactor: Make args of `reposition()` to single object

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,7 @@ export const cli = async ({
 }: Opts): Promise<number> => {
   try {
     const client = new Client({ auth: apiKey })
-    await reposition(client, databaseId, stdin, stdout)
+    await reposition({ client, databaseId, input: stdin, output: stdout })
   } catch (err: any) {
     stderr.write(err.toString())
     stderr.write('\n')

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { reposition } from './lib/reposition.js'
+export type { RepositionOpts } from './lib/reposition.js'
 export { Client } from './lib/client.js'

--- a/src/lib/reposition.ts
+++ b/src/lib/reposition.ts
@@ -6,12 +6,19 @@ import { Chan } from 'chanpuru'
 import { validateRepoItem } from './validate.js'
 import { send } from './notion.js'
 
-export async function reposition(
-  client: Client,
-  databaseId: string,
-  input: Readable,
+export type RepositionOpts = {
+  client: Client
+  databaseId: string
+  input: Readable
   output: Writable
-) {
+}
+
+export async function reposition({
+  client,
+  databaseId,
+  input,
+  output
+}: RepositionOpts) {
   const jsonStream = input.pipe(parse())
   const ch = new Chan<Promise<void>>(3, { rejectInReceiver: true })
   let err: Error | null = null

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -70,12 +70,12 @@ describe('cli', () => {
     const { mockReposition: mockRepositionFn } = (
       mockReposition as any
     )._getMocks()
-    expect(mockRepositionFn).toBeCalledWith(
-      dummyInstance,
+    expect(mockRepositionFn).toBeCalledWith({
+      client: dummyInstance,
       databaseId,
-      stdin,
-      stdout
-    )
+      input: stdin,
+      output: stdout
+    })
     expect(outData).toEqual('')
     expect(errData).toEqual('')
   })
@@ -93,12 +93,12 @@ describe('cli', () => {
 
     const { dummyInstance } = (mockClient as any)._getMocks()
     const mock = (mockReposition as any)._getMocks()
-    expect(mock.mockReposition).toBeCalledWith(
-      dummyInstance,
+    expect(mock.mockReposition).toBeCalledWith({
+      client: dummyInstance,
       databaseId,
-      stdin,
-      stdout
-    )
+      input: stdin,
+      output: stdout
+    })
     expect(outData).toEqual('')
     expect(errData).toEqual('dummy-error\n')
   })

--- a/test/lib/reposition.spec.ts
+++ b/test/lib/reposition.spec.ts
@@ -60,7 +60,12 @@ describe('reposition', () => {
     stdout.on('data', (d) => (outData = outData + d))
     const mockClient = getMockClient([])
 
-    await reposition(mockClient, databaseId, stdin, stdout)
+    await reposition({
+      client: mockClient,
+      databaseId,
+      input: stdin,
+      output: stdout
+    })
 
     expect(outData).toEqual('')
     expect(mockClient.databases.query).toBeCalledTimes(data.length)
@@ -94,7 +99,12 @@ describe('reposition', () => {
     const mockClient = getMockClient([])
 
     await expect(
-      reposition(mockClient, databaseId, stdin, stdout)
+      reposition({
+        client: mockClient,
+        databaseId,
+        input: stdin,
+        output: stdout
+      })
     ).rejects.toThrowError(
       "Validate Repo Item: must have required property 'createdAt'"
     )
@@ -129,7 +139,12 @@ describe('reposition', () => {
     })
 
     await expect(
-      reposition(mockClient, databaseId, stdin, stdout)
+      reposition({
+        client: mockClient,
+        databaseId,
+        input: stdin,
+        output: stdout
+      })
     ).rejects.toThrowError('send: query: test-error-in-query')
   })
 })


### PR DESCRIPTION
`RepositionOpts` type is exported via `index.ts`
